### PR TITLE
fix(ci): remove the double execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Remove the double action execution
now actions run when:
- a pr is created
- a pr is merged in main
- is pushed to main