### PR TITLE
feat: make request headers settable explicitly

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,5 @@
   "bracketSpacing": true,
   "jsxBracketSameLine": true,
   "semi": true,
-  "endOfLine" : "auto"
+  "endOfLine": "auto"
 }

--- a/src/infrastructure/delivery/provider/Mailchimp/index.ts
+++ b/src/infrastructure/delivery/provider/Mailchimp/index.ts
@@ -4,6 +4,7 @@ import { MailChimpResponseT, PostMessage } from './entities';
 import { date2YodaTime } from '../../../../utils/date';
 import { EmailAddressT, Mail } from '../Mail';
 import { RequestT } from '../../../network/types';
+import { headerBuildRequestBodyContentType } from '../../../network/builder/headers';
 
 const ENDPOINT_PROTOCOL_HOST = 'https://mandrillapp.com';
 const ENDPOINT_BASE = '/api/1.0/';
@@ -71,11 +72,10 @@ export class Sender implements Provider {
     try {
       const responseObj = <MailChimpResponseT[]>await request({
         basePath: ENDPOINT_PROTOCOL_HOST,
-        authorization: '',
         body: bodyPost,
         method: 'POST',
         path: endpoint,
-        content: 'JSON',
+        headers: [headerBuildRequestBodyContentType('JSON')],
       });
 
       return {

--- a/src/infrastructure/network/__tests__/undiciRequest.test.ts
+++ b/src/infrastructure/network/__tests__/undiciRequest.test.ts
@@ -1,5 +1,6 @@
 import { RequestOptions } from 'undici/types/dispatcher';
 import request from '../undiciRequest';
+import { headerBuildBearerAuthorization, headerBuildRequestBodyContentType } from '../builder/headers';
 
 const mockClientRequest = jest.fn();
 
@@ -18,16 +19,14 @@ describe('undici request supports multiple content types', () => {
     }));
     await request({
       basePath: 'https://gitbar.com',
-      authorization: '',
       method: 'GET',
       path: '/index',
-      content: 'HTML',
+      headers: [headerBuildRequestBodyContentType('HTML')],
     });
 
     const expectedRequestOptions: RequestOptions = {
       origin: '*',
       headers: {
-        authorization: `Bearer `,
         'content-type': 'text/html',
       },
       method: 'GET',
@@ -43,10 +42,9 @@ describe('undici request supports multiple content types', () => {
     }));
     await request({
       basePath: 'https://gitbar.com',
-      authorization: 'token',
       method: 'GET',
       path: '/index',
-      content: 'JSON',
+      headers: [headerBuildRequestBodyContentType('JSON'), headerBuildBearerAuthorization('token')],
     });
 
     const expectedRequestOptions: RequestOptions = {
@@ -69,10 +67,9 @@ describe('undici request supports multiple content types', () => {
     }));
     const data: string = await request({
       basePath: 'https://gitbar.com',
-      authorization: '',
       method: 'GET',
       path: '/index',
-      content: 'HTML',
+      headers: [headerBuildRequestBodyContentType('HTML')],
     });
 
     expect(data).toBe(htmlMock);
@@ -84,10 +81,10 @@ describe('undici request supports multiple content types', () => {
     }));
     const data: string = await request({
       basePath: 'https://gitbar.com',
-      authorization: '',
       method: 'GET',
       path: '/index',
-      content: 'JSON',
+      headers: [headerBuildRequestBodyContentType('JSON')],
+      responseParser: JSON.parse,
     });
 
     expect(JSON.stringify(data)).toBe(jsonMock);

--- a/src/infrastructure/network/builder/headers.ts
+++ b/src/infrastructure/network/builder/headers.ts
@@ -1,0 +1,19 @@
+type headerDescriptor = [string, string];
+const contentTypes: Record<string, string> = {
+  HTML: 'text/html',
+  JSON: 'application/json',
+};
+
+const getMimetypeFor = (type: string) => {
+  if (!Object.prototype.hasOwnProperty.call(contentTypes, type)) {
+    throw new Error(`${type} is a not supported contentType`);
+  }
+  return contentTypes[type];
+};
+
+export const headerBuildBearerAuthorization = (token: string): headerDescriptor => ['authorization', `Bearer ${token}`];
+
+export const headerBuildRequestBodyContentType = (type: string): headerDescriptor => [
+  'content-type',
+  getMimetypeFor(type),
+];

--- a/src/infrastructure/network/types.ts
+++ b/src/infrastructure/network/types.ts
@@ -1,10 +1,10 @@
-export interface RequestProps<T> {
+export interface RequestProps<T, K> {
   basePath: string;
-  authorization: string;
   method: 'POST' | 'GET' | 'PATCH';
   path: string;
   body?: T;
-  content: 'JSON' | 'HTML';
+  headers: [string, string][];
+  responseParser?: (response: string) => K;
 }
 
-export type RequestT = <T, K>(props: RequestProps<T>) => Promise<K>;
+export type RequestT = <T, K>(props: RequestProps<T, K>) => Promise<K>;

--- a/src/infrastructure/network/undiciRequest.ts
+++ b/src/infrastructure/network/undiciRequest.ts
@@ -1,19 +1,18 @@
 import { Client } from 'undici';
 import { RequestT } from './types';
 
-const contentTypes = {
-  HTML: 'text/html',
-  JSON: 'application/json',
-};
-
-const request: RequestT = async ({ basePath, authorization, method, path, body, content }) => {
+const request: RequestT = async ({
+  basePath,
+  headers,
+  method,
+  path,
+  body,
+  responseParser = <K>(response: string) => response as unknown as K,
+}) => {
   const client = new Client(basePath);
   const { body: responseBody } = await client.request({
     origin: '*',
-    headers: {
-      authorization: `Bearer ${authorization}`,
-      'content-type': contentTypes[content],
-    },
+    headers: Object.fromEntries(headers),
     method,
     path,
     body: JSON.stringify(body),
@@ -25,12 +24,7 @@ const request: RequestT = async ({ basePath, authorization, method, path, body, 
     responseString += data.toString();
   }
 
-  switch (content) {
-    case 'JSON':
-      return JSON.parse(responseString);
-    default:
-      return responseString;
-  }
+  return responseParser(responseString);
 };
 
 export default request;

--- a/src/infrastructure/store/airtable.ts
+++ b/src/infrastructure/store/airtable.ts
@@ -1,5 +1,6 @@
 import { Category, Entry } from '../../core/entities';
 import { RequestT } from '../network/types';
+import { headerBuildBearerAuthorization, headerBuildRequestBodyContentType } from '../network/builder/headers';
 
 interface AirtableProps {
   apiKey: string;
@@ -96,11 +97,11 @@ export default ({ apiKey, app, table, request }: AirtableProps): Store => {
       };
       const result = await request<SaveBodyMessage, SaveResponse>({
         basePath: 'https://api.airtable.com',
-        authorization: apiKey,
+        headers: [headerBuildBearerAuthorization(apiKey), headerBuildRequestBodyContentType('JSON')],
         method: 'POST',
         path: `/v0/${app}/${table}`,
         body,
-        content: 'JSON',
+        responseParser: JSON.parse,
       });
 
       return result?.records.length > 0;
@@ -111,11 +112,11 @@ export default ({ apiKey, app, table, request }: AirtableProps): Store => {
       };
       const result = await request<SetSentBodyMessage, SaveResponse>({
         basePath: 'https://api.airtable.com',
-        authorization: apiKey,
+        headers: [headerBuildBearerAuthorization(apiKey), headerBuildRequestBodyContentType('JSON')],
         method: 'PATCH',
         path: `/v0/${app}/${table}`,
         body,
-        content: 'JSON',
+        responseParser: JSON.parse,
       });
 
       return result?.records.length === ids.length;
@@ -123,10 +124,10 @@ export default ({ apiKey, app, table, request }: AirtableProps): Store => {
     getToSend: async () => {
       const result = await request<undefined, GetToSendResponse>({
         basePath: 'https://api.airtable.com',
-        authorization: apiKey,
+        headers: [headerBuildBearerAuthorization(apiKey), headerBuildRequestBodyContentType('JSON')],
         method: 'GET',
         path: `/v0/${app}/${table}?filterByFormula=({sentDate}="")`,
-        content: 'JSON',
+        responseParser: JSON.parse,
       });
 
       return result?.records.map(airtableToEntry);
@@ -135,10 +136,10 @@ export default ({ apiKey, app, table, request }: AirtableProps): Store => {
       // return entry or fail
       const result = await request<undefined, AirtableEntry>({
         basePath: 'https://api.airtable.com',
-        authorization: apiKey,
+        headers: [headerBuildBearerAuthorization(apiKey), headerBuildRequestBodyContentType('JSON')],
         method: 'GET',
         path: `/v0/${app}/${table}/${id}`,
-        content: 'JSON',
+        responseParser: JSON.parse,
       });
 
       return result && airtableToEntry(result);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "ES2018",
     "module": "commonjs",
-    "lib": ["es2018", "dom"],
+    "lib": ["es2019", "dom"],
     "declaration": true,
     "jsx": "react-jsx",
     "strict": true,


### PR DESCRIPTION
Added helper to make it simpler. Decoupling the content type of request from content type of response.

This is just a proposal and it should give us more flexibility